### PR TITLE
Resolves Next Transition & On Air processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
 		"typedoc": "^0.26.8",
 		"typescript": "~5.5.4",
 		"typescript-eslint": "^8.8.1"
-	}
+	},
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/functions/mixEffect/actionId.ts
+++ b/src/functions/mixEffect/actionId.ts
@@ -20,6 +20,7 @@ export enum ActionId {
 	TransitionWipeFillSource = 'transitionWipeFillSource',
 	TransitionSourceBG = 'transitionSourceBG', // @deprecated
 	NextTransitionButtons = 'transitionSource',
+	OnAirButtons = 'onAirButtons', // this is a custom function for KEY and DSK On Air
 	USKOnPreview = 'uskOnPreview', // @deprecated This is custom function
 	KeyOnAir = 'keyOnAir', // needed for communications; action is deprecated
 	DskOnAir = 'dskOnAir', // needed for communications; action is deprecated

--- a/src/functions/mixEffect/actionId.ts
+++ b/src/functions/mixEffect/actionId.ts
@@ -18,9 +18,9 @@ export enum ActionId {
 	TransitionWipeSoftness = 'transitionWipeSoftness',
 	TransitionWipeBorder = 'transitionWipeBorder',
 	TransitionWipeFillSource = 'transitionWipeFillSource',
-	TransitionSourceBG = 'transitionSourceBG',
-	TransitionSource = 'transitionSource',
-	USKOnPreview = 'uskOnPreview', // This is custom function
-	KeyOnAir = 'keyOnAir',
-	DskOnAir = 'dskOnAir',
+	TransitionSourceBG = 'transitionSourceBG', // @deprecated
+	NextTransitionButtons = 'transitionSource',
+	USKOnPreview = 'uskOnPreview', // @deprecated This is custom function
+	KeyOnAir = 'keyOnAir', // needed for communications; action is deprecated
+	DskOnAir = 'dskOnAir', // needed for communications; action is deprecated
 }

--- a/src/functions/mixEffect/actions.ts
+++ b/src/functions/mixEffect/actions.ts
@@ -498,7 +498,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 				if (isNaN(operation) || operation === undefined || operation < 0 || operation > 4) {
 					console.log('Next Transition:Tie key to next transition - Unknown ButtonAction: ' + action.options.operation)
 					return
-				} else if (keyName === undefined || state.nextTState.isChoiceValid(keyName, true)) {
+				} else if (keyName === undefined || !state.nextTState.isChoiceValid(keyName, true)) {
 					console.log('Next Transition:Tie key to next transition - Unknown KeyButton: ' + action.options.KeyButton)
 					return
 				} else if (operation === 0) {
@@ -556,7 +556,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 				if (isNaN(operation) || operation === undefined || operation < 0 || operation > 5) {
 					console.log('Next Transition:Key On Air - Unknown ButtonAction: ' + action.options.operation)
 					return
-				} else if (keyName === undefined || state.nextTState.isChoiceValid(keyName, false)) {
+				} else if (keyName === undefined || !state.nextTState.isChoiceValid(keyName, false)) {
 					console.log('Next Transition:Key On Air - Unknown KeyButton: ' + action.options.KeyButton)
 					return
 				} else if (operation === 0 || operation == 3) {

--- a/src/functions/mixEffect/actions.ts
+++ b/src/functions/mixEffect/actions.ts
@@ -331,7 +331,8 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 		//  Next Transition block of buttons: On Air (USK), On Air (DSK), KEY (USK), DSK, BKGD
 		//----------------->>>>>>
 		[ActionId.TransitionSourceBG]: {
-			name: createActionName('Change transition selection'),
+			// this incorrectly resets KEY and DSK and also does other than what the name says.
+			name: 'Deprecated & broken, use \'Set "Next Transition" Button\' (Change transition selection)',
 			options: [
 				{
 					type: 'checkbox',
@@ -350,7 +351,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 			},
 		},
 		[ActionId.KeyOnAir]: {
-			name: createActionName('Set USK OnAir'),
+			name: 'Deprecated, use \'Set "On Air" Button\' (Set USK OnAir)',
 			options: [
 				{
 					type: 'dropdown',
@@ -378,7 +379,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 			},
 		},
 		[ActionId.DskOnAir]: {
-			name: createActionName('Set DSK OnAir'),
+			name: 'Deprecated, use \'Set "On Air" Button\' (Set DSK OnAir)',
 			options: [
 				{
 					type: 'dropdown',
@@ -406,7 +407,8 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 			},
 		},
 		[ActionId.USKOnPreview]: {
-			name: createActionName('Set USK on preview bus'),
+			name: 'Deprecated & broken, use \'Set "Next Transition" Button\' (Set USK on preview bus)',
+			// this always turns off DSK! Also this was rewritten from 1.3.1  by JF with different 'id' values so it breaks any existing instances as well.
 			options: [
 				{
 					type: 'dropdown',
@@ -446,9 +448,9 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 			},
 		},
 		[ActionId.NextTransitionButtons]: {
-			name: createActionName('Set Next Transition Button (KEY, DSK, BKGD)'),
+			name: createActionName('Set "Next Transition" Button (KEY, DSK, or BKGD)'),
 			description:
-				'Set a button in the Next Transition group: On/Off/Toggle is equivalent to pressing the button: its effect on PVW depends on the state of "On Air". The last two options ensure that the action affects PVW independently of the state of "On Air"',
+				'Set a button in the Next Transition group: On/Off/Toggle is the normal "Tie" behavior: its effect on PVW depends on the state of "On Air". The last two options ensure that the key is On/Off PVW regardless of the state of "On Air"',
 			options: [
 				{
 					type: 'dropdown',
@@ -465,8 +467,8 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 						{ id: 0, label: 'Off' },
 						{ id: 1, label: 'On' },
 						{ id: 2, label: 'Toggle' },
-						{ id: 3, label: 'Off PVW only' },
-						{ id: 4, label: 'On PVW only' },
+						{ id: 3, label: 'Off PVW' },
+						{ id: 4, label: 'On PVW' },
 					],
 					default: 0,
 					isVisible: (options) => options.KeyButton != 'BKGD',
@@ -522,9 +524,9 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 			},
 		},
 		[ActionId.OnAirButtons]: {
-			name: createActionName('Set an On Air Button (KEY or DSK)'),
+			name: createActionName('Set "On Air" Button (KEY or DSK)'),
 			description:
-				'Set an "On Air" button: On/Off/Toggle is equivalent to pressing the button, so it will affect both PGM and PVW. The last three options ensure that the action affects PGM only (althought PVW may flicker)',
+				'Set an "On Air" button. On/Off/Toggle is the "normal" behavior, showing/hiding in PGM and flipping the visibility in PVW. The last three options ensure that the action affects PGM only (althought PVW may flicker)',
 			options: [
 				{
 					type: 'dropdown',

--- a/src/functions/mixEffect/feedbackId.ts
+++ b/src/functions/mixEffect/feedbackId.ts
@@ -15,10 +15,10 @@ export enum FeedbackId {
 	FadeToBlackIsBlack = 'fadeToBlackIsBlack',
 	FadeToBlackRate = 'fadeToBlackRate',
 	FTBAFV = 'FTBAFV',
-	NextTransitionState = 'transitionSource',
-	TransitionSelection = 'transitionSelection',
+	KeysVisibility = 'transitionSource', // keeping the string for backward compatibility?
+	TransitionSelection = 'transitionSelection', // @deprecated
 	TransitionKeySwitch = 'transitionKeySwitch', // @deprecated
-	KeyOnAir = 'keyOnAir',
-	DskOnAir = 'dskOnAir',
-	KeyOnPvw = 'keyOnPvw',
+	KeyOnAir = 'keyOnAir', // @deprecated
+	DskOnAir = 'dskOnAir', // @deprecated
+	KeyOnPvw = 'keyOnPvw', // @deprecated
 }

--- a/src/functions/mixEffect/feedbackId.ts
+++ b/src/functions/mixEffect/feedbackId.ts
@@ -15,9 +15,9 @@ export enum FeedbackId {
 	FadeToBlackIsBlack = 'fadeToBlackIsBlack',
 	FadeToBlackRate = 'fadeToBlackRate',
 	FTBAFV = 'FTBAFV',
-	TransitionSource = 'transitionSource',
+	NextTransitionState = 'transitionSource',
 	TransitionSelection = 'transitionSelection',
-	TransitionKeySwitch = 'transitionKeySwitch',
+	TransitionKeySwitch = 'transitionKeySwitch', // @deprecated
 	KeyOnAir = 'keyOnAir',
 	DskOnAir = 'dskOnAir',
 	KeyOnPvw = 'keyOnPvw',

--- a/src/functions/mixEffect/feedbacks.ts
+++ b/src/functions/mixEffect/feedbacks.ts
@@ -1,4 +1,5 @@
 import { combineRgb, CompanionFeedbackDefinitions } from '@companion-module/base'
+import { getOptNumber, getOptString } from '../../util'
 import { TransitionStyle } from '../../enums'
 import { FeedbackId } from './feedbackId'
 import { TransitionStyleChoice, SwitchChoices, KeySwitchChoices } from '../../model'
@@ -61,22 +62,22 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 				}
 			},
 		},
-		[FeedbackId.TransitionSource]: {
+		[FeedbackId.NextTransitionState]: {
 			type: 'boolean',
-			name: createFeedbackName('Transition key state'),
-			description: 'Change bank style based on transition key state',
+			name: createFeedbackName('State of Next Transition buttons'),
+			description: 'Change button style based on state of a "next transition" button (KEY, DSK, BKGD)',
 			options: [
 				{
 					type: 'dropdown',
-					label: 'Switch',
-					id: 'KeySwitch',
-					choices: KeySwitchChoices,
-					default: 2,
+					label: 'Layer',
+					id: 'KeyButton',
+					choices: state.nextTState.getChoices(true),
+					default: state.nextTState.getDefaultChoice(),
 				},
 				{
 					type: 'dropdown',
-					label: 'Key Tied',
-					id: 'OnOffSwitch',
+					label: 'State',
+					id: 'ButtonAction',
 					choices: [
 						{ id: 0, label: 'On' },
 						{ id: 1, label: 'Off' },
@@ -89,19 +90,10 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 				bgcolor: combineRgb(255, 255, 0),
 			},
 			callback: (feedback) => {
-				const key = feedback.options.KeySwitch
-				const keystate = feedback.options.OnOffSwitch!
-				if (keystate === 0) {
-					if (key === 0) return (state.transitionKeys & TransitionKey.USK) !== 0
-					if (key === 1) return (state.transitionKeys & TransitionKey.DSK) !== 0
-					if (key === 2) return (state.transitionKeys & TransitionKey.BKGD) !== 0
-				} else if (keystate === 1) {
-					if (key === 0) return (state.transitionKeys & TransitionKey.USK) === 0
-					if (key === 1) return (state.transitionKeys & TransitionKey.DSK) === 0
-					if (key === 2) return (state.transitionKeys & TransitionKey.BKGD) === 0
-				}
+				const keyName = getOptString(feedback, 'KeyButton')
+				const keystate = getOptNumber(feedback, 'ButtonAction')
 
-				return false
+				return keystate == 0 ? state.nextTState[keyName] : !state.nextTState[keyName]
 			},
 		},
 		[FeedbackId.KeyOnAir]: {
@@ -125,7 +117,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 				bgcolor: combineRgb(255, 255, 0),
 			},
 			callback: (feedback) => {
-				return feedback.options.KeyOnAir === 1 ? state.keyOnAir : !state.keyOnAir
+				return feedback.options.KeyOnAir === 1 ? state.nextTState.keyOnAir : !state.nextTState.keyOnAir
 			},
 		},
 		[FeedbackId.DskOnAir]: {
@@ -149,7 +141,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 				bgcolor: combineRgb(255, 255, 0),
 			},
 			callback: (feedback) => {
-				return feedback.options.DSKOnAir === 1 ? state.dskOnAir : !state.dskOnAir
+				return feedback.options.DSKOnAir === 1 ? state.nextTState.dskOnAir : !state.nextTState.dskOnAir
 			},
 		},
 		[FeedbackId.KeyOnPvw]: {

--- a/src/functions/mixEffect/state.ts
+++ b/src/functions/mixEffect/state.ts
@@ -28,11 +28,35 @@ export class nextTransitionState {
 	getDefaultChoice(): string {
 		return 'KEY'
 	}
-	getOnAirStatus(NTKey:string): boolean {
-		if (NTKey.toUpperCase() == "KEY") {
+	isChoiceValid(choice: string, includeBKGD: boolean): boolean {
+		const keynames = ['KEY', 'DSK']
+		if (includeBKGD) {
+			keynames.push('BKGD')
+		}
+		return keynames.includes(choice)
+	}
+	getOnAirStatus(NTKey: string): boolean {
+		if (NTKey.toUpperCase() == 'KEY') {
 			return this.keyOnAir
 		} else {
 			return this.dskOnAir
+		}
+	}
+	setOnAirStatus(NTKey: string, value: boolean): void {
+		if (NTKey.toUpperCase() == 'KEY') {
+			this.keyOnAir = value
+		} else {
+			this.dskOnAir = value
+		}
+	}
+	getOnAirCommand(NTKey: string): any {
+		switch (NTKey) {
+			case 'KEY':
+				return { id: ActionId.KeyOnAir, type: ReqType.Set, value: [this.keyOnAir ? 1 : 0] }
+			case 'DSK':
+				return { id: ActionId.DskOnAir, type: ReqType.Set, value: [this.dskOnAir ? 1 : 0] }
+			default:
+				console.log('getOnAirCommand called with illegal argument: ' + NTKey)
 		}
 	}
 	pack(): number {

--- a/src/functions/mixEffect/state.ts
+++ b/src/functions/mixEffect/state.ts
@@ -16,7 +16,7 @@ export class nextTransitionState {
 	keyOnAir = false
 	dskOnAir = false
 	// don't need an explicit constructor
-	getChoices(includeBKGD: boolean): any {
+	getChoices(includeBKGD = true): any {
 		const choices: string[] = ['KEY', 'DSK']
 		if (includeBKGD) {
 			choices.push('BKGD')
@@ -28,7 +28,7 @@ export class nextTransitionState {
 	getDefaultChoice(): string {
 		return 'KEY'
 	}
-	isChoiceValid(choice: string, includeBKGD: boolean): boolean {
+	isChoiceValid(choice: string, includeBKGD = true): boolean {
 		const keynames = ['KEY', 'DSK']
 		if (includeBKGD) {
 			keynames.push('BKGD')

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,10 @@
-import type { CompanionActionEvent } from '@companion-module/base'
+import type { CompanionActionEvent, CompanionFeedbackInfo } from '@companion-module/base'
 
-export function getOptNumber(action: CompanionActionEvent, key: string, defVal?: number): number {
+export function getOptNumber(
+	action: CompanionActionEvent | CompanionFeedbackInfo,
+	key: string,
+	defVal?: number,
+): number {
 	const rawVal = action.options[key]
 	if (defVal !== undefined && rawVal === undefined) return defVal
 	const val = Number(rawVal)
@@ -10,7 +14,11 @@ export function getOptNumber(action: CompanionActionEvent, key: string, defVal?:
 	return val
 }
 
-export function getOptString(action: CompanionActionEvent, key: string, defVal?: string): string {
+export function getOptString(
+	action: CompanionActionEvent | CompanionFeedbackInfo,
+	key: string,
+	defVal?: string,
+): string {
 	const rawVal = action.options[key]
 	if (defVal !== undefined && rawVal === undefined) return defVal
 	const val = String(rawVal)


### PR DESCRIPTION
This PR resolves all known (and several unreported) issues in Next Transition/On Air processing in the mixEffect module:
Issue #45 - Feedback for "show key in PVW" is missing
Issue #54 - Bugs, Features for nextTransition (and code organization for the same)
Issue #55 - Add DSK on PVW feature
Issue #66 - Labels for GSD buttons in the "Next Transition" block should be labeled as such
Issue #67 - Internal Feature: Next Transition functionality should be better encapsulated
Issue #68 - Feature/bug: remove duplicate function TransitionKeySwitch
Issue #74 - Feature: Consolidate Next Transition actions

This PR marks many of the currently-defined Next Transition / On Air actions and feedbacks as deprecated. Many of these functions do not work properly, so probably could be deleted in the next release (1.4.1 or 1.5). We can also look into writing upgrade scripts for those that currently work.