### PR TITLE
Add generic framework for upgrades and specific upgrades NextTransition

### DIFF
--- a/src/functions/mixEffect/actionId.ts
+++ b/src/functions/mixEffect/actionId.ts
@@ -18,10 +18,8 @@ export enum ActionId {
 	TransitionWipeSoftness = 'transitionWipeSoftness',
 	TransitionWipeBorder = 'transitionWipeBorder',
 	TransitionWipeFillSource = 'transitionWipeFillSource',
-	TransitionSourceBG = 'transitionSourceBG', // @deprecated
 	NextTransitionButtons = 'transitionSource',
 	OnAirButtons = 'onAirButtons', // this is a custom function for KEY and DSK On Air
-	USKOnPreview = 'uskOnPreview', // @deprecated This is custom function
-	KeyOnAir = 'keyOnAir', // needed for communications; action is deprecated
-	DskOnAir = 'dskOnAir', // needed for communications; action is deprecated
+	KeyOnAir = 'keyOnAir', // needed for communications
+	DskOnAir = 'dskOnAir', // needed for communications
 }

--- a/src/functions/mixEffect/actions.ts
+++ b/src/functions/mixEffect/actions.ts
@@ -5,7 +5,7 @@ import { sendCommand, sendCommands } from '../../connection'
 import type { CompanionActionDefinitions } from '@companion-module/base'
 import { TransitionStyleChoice, WipeDirectionChoices, SwitchChoices } from '../../model'
 import { GoStreamModel } from '../../models/types'
-import { MixEffectStateT, TransitionKey } from './state'
+import { MixEffectStateT } from './state'
 
 function createActionName(name: string): string {
 	return 'MixEffect: ' + name
@@ -330,123 +330,6 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 		//---------------------------------------------------------------------------------------
 		//  Next Transition block of buttons: On Air (USK), On Air (DSK), KEY (USK), DSK, BKGD
 		//----------------->>>>>>
-		[ActionId.TransitionSourceBG]: {
-			// this incorrectly resets KEY and DSK and also does other than what the name says.
-			name: 'Deprecated & broken, use \'Set "Next Transition" Button\' (Change transition selection)',
-			options: [
-				{
-					type: 'checkbox',
-					label: 'Background',
-					id: 'Background',
-					default: false,
-				},
-			],
-			callback: async (action) => {
-				let num = 0
-				const bg = action.options.Background
-				if (bg === true) {
-					num += 1 << 2
-				}
-				await sendCommand(ActionId.NextTransitionButtons, ReqType.Set, [num])
-			},
-		},
-		[ActionId.KeyOnAir]: {
-			name: 'Deprecated, use \'Set "On Air" Button\' (Set USK OnAir)',
-			options: [
-				{
-					type: 'dropdown',
-					label: 'USK OnAir',
-					id: 'KeyOnAir',
-					choices: [
-						{ id: 0, label: 'Off' },
-						{ id: 1, label: 'On Air' },
-						{ id: 2, label: 'Toggle' },
-					],
-					default: 2,
-				},
-			],
-			callback: async (action) => {
-				const opt = getOptNumber(action, 'KeyOnAir')
-				let paramOpt = opt
-				if (opt === 2) {
-					if (state.nextTState.keyOnAir === true) {
-						paramOpt = 0
-					} else {
-						paramOpt = 1
-					}
-				}
-				await sendCommand(ActionId.KeyOnAir, ReqType.Set, [paramOpt])
-			},
-		},
-		[ActionId.DskOnAir]: {
-			name: 'Deprecated, use \'Set "On Air" Button\' (Set DSK OnAir)',
-			options: [
-				{
-					type: 'dropdown',
-					label: 'DSK OnAir',
-					id: 'DSKOnAir',
-					choices: [
-						{ id: 0, label: 'Off' },
-						{ id: 1, label: 'On Air' },
-						{ id: 2, label: 'Toggle' },
-					],
-					default: 0,
-				},
-			],
-			callback: async (action) => {
-				const opt = getOptNumber(action, 'DSKOnAir')
-				let paramOpt = opt
-				if (opt === 2) {
-					if (state.nextTState.dskOnAir === true) {
-						paramOpt = 0
-					} else {
-						paramOpt = 1
-					}
-				}
-				await sendCommand(ActionId.DskOnAir, ReqType.Set, [paramOpt])
-			},
-		},
-		[ActionId.USKOnPreview]: {
-			name: 'Deprecated & broken, use \'Set "Next Transition" Button\' (Set USK on preview bus)',
-			// this always turns off DSK! Also this was rewritten from 1.3.1  by JF with different 'id' values so it breaks any existing instances as well.
-			options: [
-				{
-					type: 'dropdown',
-					label: 'State',
-					id: 'USKPvwState',
-					choices: [
-						{ id: 0, label: 'Off' },
-						{ id: 1, label: 'On' },
-						{ id: 2, label: 'Toggle' },
-					],
-					default: 0,
-				},
-			],
-			callback: async (action) => {
-				let nextState = action.options.USKPvwState
-
-				if (nextState === 2) {
-					// Figure out if it is visible in pvw or not
-					if (state.tied && !(state.transitionKeys & TransitionKey.USK))
-						// it is currently visible, so should be hidden
-						nextState = 4
-					else if (!state.tied && state.transitionKeys & TransitionKey.USK)
-						// it is currently visible, so should be hidden. As it is on air we do this by tie:ing
-						nextState = 5
-					else if (state.tied && state.transitionKeys & TransitionKey.USK)
-						// it is currently hidden, so should be visible. As it is on air we do this by untie:ing
-						nextState = 4
-					else if (!state.tied && !(state.transitionKeys & TransitionKey.USK))
-						// it is currently hidden, so should be visible
-						nextState = 5
-				} else if (state.transitionKeys & TransitionKey.USK) {
-					// Invert next state if On Air is true
-					nextState = nextState === 5 ? 4 : 5
-				}
-
-				await sendCommand(ActionId.NextTransitionButtons, ReqType.Set, [nextState])
-			},
-		},
 		[ActionId.NextTransitionButtons]: {
 			name: createActionName('Set "Next Transition" Button (KEY, DSK, or BKGD)'),
 			description:

--- a/src/functions/mixEffect/feedbackId.ts
+++ b/src/functions/mixEffect/feedbackId.ts
@@ -16,9 +16,4 @@ export enum FeedbackId {
 	FadeToBlackRate = 'fadeToBlackRate',
 	FTBAFV = 'FTBAFV',
 	KeysVisibility = 'transitionSource', // keeping the string for backward compatibility?
-	TransitionSelection = 'transitionSelection', // @deprecated
-	TransitionKeySwitch = 'transitionKeySwitch', // @deprecated
-	KeyOnAir = 'keyOnAir', // @deprecated
-	DskOnAir = 'dskOnAir', // @deprecated
-	KeyOnPvw = 'keyOnPvw', // @deprecated
 }

--- a/src/functions/mixEffect/feedbacks.ts
+++ b/src/functions/mixEffect/feedbacks.ts
@@ -2,9 +2,9 @@ import { combineRgb, CompanionFeedbackDefinitions } from '@companion-module/base
 import { getOptNumber, getOptString } from '../../util'
 import { TransitionStyle } from '../../enums'
 import { FeedbackId } from './feedbackId'
-import { TransitionStyleChoice, SwitchChoices, KeySwitchChoices } from '../../model'
+import { TransitionStyleChoice } from '../../model'
 import { GoStreamModel } from '../../models/types'
-import { MixEffectStateT, TransitionKey } from './state'
+import { MixEffectStateT } from './state'
 
 function createFeedbackName(name: string): string {
 	return 'MixEffect: ' + name
@@ -107,80 +107,6 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 					return state.nextTState.getOnAirStatus(keyName)
 				} else {
 					console.log('Feedback: Next Transition state received illegal option: ' + keystate)
-				}
-			},
-		},
-		[FeedbackId.KeyOnAir]: {
-			type: 'boolean',
-			name: 'Deprecated use: \'"Next Transition" / "On Air" state\' (KEY "On Air" state)',
-			description: 'Change bank style based on KEY (USK) OnAir state',
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Key OnAir',
-					id: 'KeyOnAir',
-					choices: [
-						{ id: 0, label: 'Off' },
-						{ id: 1, label: 'On' },
-					],
-					default: 1,
-				},
-			],
-			defaultStyle: {
-				color: combineRgb(0, 0, 0),
-				bgcolor: combineRgb(255, 255, 0),
-			},
-			callback: (feedback) => {
-				return feedback.options.KeyOnAir === 1 ? state.nextTState.keyOnAir : !state.nextTState.keyOnAir
-			},
-		},
-		[FeedbackId.DskOnAir]: {
-			type: 'boolean',
-			name: 'Deprecated use: \'"Next Transition" / "On Air" state\' (DSK "On Air" state)',
-			description: 'Change bank style based on DSK OnAir state',
-			options: [
-				{
-					type: 'dropdown',
-					label: 'DSK OnAir',
-					id: 'DSKOnAir',
-					choices: [
-						{ id: 0, label: 'Off' },
-						{ id: 1, label: 'On' },
-					],
-					default: 1,
-				},
-			],
-			defaultStyle: {
-				color: combineRgb(0, 0, 0),
-				bgcolor: combineRgb(255, 255, 0),
-			},
-			callback: (feedback) => {
-				return feedback.options.DSKOnAir === 1 ? state.nextTState.dskOnAir : !state.nextTState.dskOnAir
-			},
-		},
-		[FeedbackId.KeyOnPvw]: {
-			// note state.pvwOnAir is never updated so this feedback never returns true
-			type: 'boolean',
-			name: 'Deprecated and broken use: \'"Next Transition" / "On Air" state\' (KEY (USK) visible in preview (PVW))',
-			description: 'Indicates if USK on on air on the preview bus',
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Key OnAir',
-					id: 'KeyOnAir',
-					choices: SwitchChoices,
-					default: 1,
-				},
-			],
-			defaultStyle: {
-				color: combineRgb(0, 0, 0),
-				bgcolor: combineRgb(0, 255, 0),
-			},
-			callback: (feedback) => {
-				if (state.pvwOnAir && feedback.options.KeyOnAir === 1) {
-					return true
-				} else {
-					return false
 				}
 			},
 		},
@@ -307,110 +233,6 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 				} else {
 					return undefined
 				}
-			},
-		},
-		[FeedbackId.TransitionSelection]: {
-			// The only thing this feedback adds is a combined Key && BKGD status,
-			//    which can be done using the internal "Logic: AND"
-			// Also it doesn't include DSK.
-			type: 'boolean',
-			name: 'Deprecated use: \'"Next Transition" / "On Air" state\' (and "Logic: AND" if needed) (Transition selection)',
-			description: 'If the specified transition selection is active, change style of the bank',
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Match method',
-					id: 'MatchState',
-					choices: [
-						{ id: 0, label: 'Exact' },
-						{ id: 1, label: 'Contains' },
-					],
-					default: 2,
-				},
-				{
-					type: 'checkbox',
-					label: 'Background',
-					id: 'Background',
-					default: false,
-				},
-				{
-					type: 'checkbox',
-					label: 'Key',
-					id: 'Key',
-					default: false,
-				},
-			],
-			defaultStyle: {
-				color: combineRgb(0, 0, 0),
-				bgcolor: combineRgb(255, 255, 0),
-			},
-			callback: (feedback) => {
-				const seleOptions = feedback.options.MatchState
-				const BG = feedback.options.Background
-				const Key = feedback.options.Key
-				const BKGDArmed = (state.transitionKeys & TransitionKey.BKGD) > 0
-				const USKArmed = (state.transitionKeys & TransitionKey.USK) > 0
-				switch (seleOptions) {
-					case 0:
-						if ((BG && BKGDArmed) || (Key && USKArmed)) {
-							return true
-						} else if (BG && Key) {
-							return BKGDArmed && USKArmed
-						} else {
-							return false
-						}
-					case 1:
-						if (BG && Key) {
-							return BKGDArmed || USKArmed
-						} else {
-							if (BG) {
-								return BKGDArmed
-							} else if (Key) {
-								return USKArmed
-							} else {
-								return false
-							}
-						}
-					default:
-						return false
-				}
-			},
-		},
-		[FeedbackId.TransitionKeySwitch]: {
-			// note that this doesn't work as coded, since the callback code expects a multidropdown type,
-			//  but the options specifies 'dropdown.
-			// The add value of the logic also seems questionable (return true if any of the selected options are on)
-			type: 'boolean',
-			name: 'Deprecated and broken use: \'"Next Transition" / "On Air" state\' (Transition key switch)',
-			description: 'Set the special effect Transition key switch',
-			options: [
-				{
-					type: 'dropdown',
-					label: 'Switch',
-					id: 'KeySwitch',
-					choices: KeySwitchChoices,
-					default: 2,
-				},
-			],
-			defaultStyle: {
-				color: combineRgb(0, 0, 0),
-				bgcolor: combineRgb(255, 255, 0),
-			},
-			callback: (feedback) => {
-				const seleOptions = feedback.options.KeySwitch
-				if (seleOptions && Array.isArray(seleOptions)) {
-					const arratOptions = Array.from(seleOptions)
-					if (arratOptions.includes(0) && state.transitionKeys & TransitionKey.USK) {
-						return true
-					}
-					if (arratOptions.includes(1) && state.transitionKeys & TransitionKey.DSK) {
-						return true
-					}
-					if (arratOptions.includes(2) && state.transitionKeys & TransitionKey.BKGD) {
-						return true
-					}
-					return false
-				} else return false
 			},
 		},
 	}

--- a/src/functions/mixEffect/state.ts
+++ b/src/functions/mixEffect/state.ts
@@ -81,13 +81,6 @@ export class nextTransitionState {
 	}
 }
 
-/* @deprecated */
-export enum TransitionKey {
-	USK = 1 << 0,
-	DSK = 1 << 1,
-	BKGD = 1 << 2,
-}
-
 export type MixEffectStateT = {
 	PvwSrc: number
 	PgmSrc: number
@@ -110,7 +103,6 @@ export type MixEffectStateT = {
 	}
 	pvwOnAir: boolean
 	tied: boolean
-	transitionKeys: number // @deprecated
 	nextTState: nextTransitionState
 }
 
@@ -137,7 +129,6 @@ export function create(_model: GoStreamModel): MixEffectStateT {
 		},
 		pvwOnAir: false,
 		tied: false,
-		transitionKeys: TransitionKey.BKGD,
 		nextTState: new nextTransitionState(),
 	}
 }
@@ -226,7 +217,6 @@ export function update(state: MixEffectStateT, data: GoStreamCmd): boolean {
 		}
 		case ActionId.NextTransitionButtons:
 			// Next Transition group (KEY, DSK, BKGD)
-			state.transitionKeys = data.value[0] // @deprecated
 			state.nextTState.unpackNTState(data.value[0])
 			break
 	}

--- a/src/model.ts
+++ b/src/model.ts
@@ -46,11 +46,6 @@ export const WipeDirectionChoices = [
 	{ id: 0, label: 'Normal' },
 	{ id: 1, label: 'Inverse' },
 ]
-export const KeySwitchChoices = [
-	{ id: 0, label: 'Key' },
-	{ id: 1, label: 'DSK' },
-	{ id: 2, label: 'BKGD' },
-]
 export const SuperSourceChoices = [
 	{ id: 0, label: 'Source 1' },
 	{ id: 1, label: 'Source 2' },

--- a/src/upgrades/index.ts
+++ b/src/upgrades/index.ts
@@ -24,10 +24,10 @@ type UpdConfig = CompanionStaticUpgradeProps<Config>
 
 // return a function that will receive a set of actions,feedbacks and config and must return the upgraded ones.
 // This returned function sends each action/feedback to the functions passed in here as `actionsUpgrader` and `feedbackUpgrader`.
-//    the actionsUpgrader/feedbackUpgrader funcs take a single argument (one action or feedback)
-//    and is called once for each action or feedback currently defined
-//        it should return true only if the action was updated.
-//        The Upgrader functions must modify the passed object, not create a new one (JavaScript does not copy on write)
+// The actionsUpgrader/feedbackUpgrader funcs take a single argument (one action or feedback)
+// and is called once for each action or feedback currently defined
+// it should return true only if the action was updated.
+// The Upgrader functions must modify the passed object, not create a new one (JavaScript does not copy on write)
 export function ModuleUpgrader(
 	actionsUpgrader: actionUpgradeFn = falseFn,
 	feedbackUpgrader: feedbackUpgradeFn = falseFn,

--- a/src/upgrades/index.ts
+++ b/src/upgrades/index.ts
@@ -1,7 +1,51 @@
-import * as UpgradeToConsolidatedSSRCMaskAction from './upgradeToConsolidatedSSRCMaskAction'
 import { Config } from '../config'
-import { CompanionStaticUpgradeScript } from '@companion-module/base'
+import {
+	CompanionUpgradeContext,
+	CompanionStaticUpgradeProps,
+	CompanionMigrationAction,
+	CompanionStaticUpgradeScript,
+	CompanionMigrationFeedback,
+} from '@companion-module/base'
 
+import * as UpgradeToConsolidatedSSRCMaskAction from './upgradeToConsolidatedSSRCMaskAction'
+import { tryUpdateNTAction, tryUpdateNTFeedback } from './upgradeNextTransitiontov1-4'
+
+// The following functions are modified from:
+//   https://github.com/bitfocus/companion-module-allenheath-sq/blob/main/src/upgrades.ts
+//  used with permission
+type actionUpgradeFn = (action: CompanionMigrationAction) => boolean
+type feedbackUpgradeFn = (action: CompanionMigrationFeedback) => boolean
+type configUpgradeFn = (config: Config | null) => boolean
+const falseFn = () => false
+
+type UpdateScript = CompanionStaticUpgradeScript<Config>
+type UpdContext = CompanionUpgradeContext<Config>
+type UpdConfig = CompanionStaticUpgradeProps<Config>
+
+// return a function that will receive a set of actions,feedbacks and config and must return the upgraded ones.
+// This returned function sends each action/feedback to the functions passed in here as `actionsUpgrader` and `feedbackUpgrader`.
+//    the actionsUpgrader/feedbackUpgrader funcs take a single argument (one action or feedback)
+//    and is called once for each action or feedback currently defined
+//        it should return true only if the action was updated.
+//        The Upgrader functions must modify the passed object, not create a new one (JavaScript does not copy on write)
+export function ModuleUpgrader(
+	actionsUpgrader: actionUpgradeFn = falseFn,
+	feedbackUpgrader: feedbackUpgradeFn = falseFn,
+	configUpgrader: configUpgradeFn = falseFn,
+): UpdateScript {
+	return (_context: UpdContext, props: UpdConfig) => {
+		return {
+			updatedActions: props.actions.filter(actionsUpgrader),
+			updatedConfig: configUpgrader(props.config) ? props.config : null,
+			updatedFeedbacks: props.feedbacks.filter(feedbackUpgrader),
+		}
+	}
+}
+
+// The list of upgrade scripts that will be passed to Companion's init method...
+//  Note: the number of items in this list must grow monotonically, and new items must be added to the end for this to work properly
+//    (In some cases very old upgraders can be replaced by EmptyUpgradeScript)
 export const UpgradeScriptList: CompanionStaticUpgradeScript<Config>[] = [
 	UpgradeToConsolidatedSSRCMaskAction.getScripts,
+	ModuleUpgrader(tryUpdateNTAction, tryUpdateNTFeedback),
 ]

--- a/src/upgrades/upgradeNextTransitiontov1-4.ts
+++ b/src/upgrades/upgradeNextTransitiontov1-4.ts
@@ -1,0 +1,107 @@
+import {
+	//	CompanionStaticUpgradeResult,
+	//	CompanionUpgradeContext,
+	//	CompanionStaticUpgradeProps,
+	CompanionMigrationAction,
+	CompanionMigrationFeedback,
+	InputValue,
+	//CompanionOptionValues,
+} from '@companion-module/base'
+
+import { ActionId } from '../functions/mixEffect/actionId'
+import { FeedbackId } from '../functions/mixEffect/feedbackId'
+
+// note: use string constants rather than variables for the comparisons
+//   so we are not dependent on code changes down the line
+//  (these conversion are supposed to persist beyond any code removals)
+
+// note: unlike some languages, these modification affect the original object (no copy on write)
+
+const keyswitchMap = { '0': 'KEY', '1': 'DSK', '2': 'BKGD' }
+
+export function tryUpdateNTAction(action: CompanionMigrationAction): boolean {
+	const { actionId, options } = action
+	const uskOnPvwMapping = [2, 0, 0, 0, 3, 4] // (5 = on, 4 = off, 0 = toggle) ==> (2 = Toggle, 3 = Off PVW, 4 = On PVW)
+	let keyName: InputValue
+	switch (actionId) {
+		case 'transitionSource':
+			// in 1.3.1 option type was incorrectly set to dropdown, so it didn't work. This is a bit of handwaving...
+			//  If it was, indeed, a single-choice dropdown it would only turn the key on; never off...
+			if (Object.keys(options).includes('KeySwitch')) {
+				action.actionId = ActionId.NextTransitionButtons // this is a no-op
+				keyName = keyswitchMap[String(options['KeySwitch'])]
+				action.options = { KeyButton: keyName, ButtonAction: 1, BKGDAction: 1 }
+				return true
+			} else {
+				// first optionis now called 'KeyButton', no need to test
+				return false
+			}
+		case 'transitionSourceBG':
+			action.actionId = ActionId.NextTransitionButtons
+			action.options = { KeyButton: 'BKGD', ButtonAction: 0, BKGDAction: options['Background'] ? 1 : 0 }
+			return true
+		case 'uskOnPreview':
+			// upgrade from 1.3.1 (ignore changes made before 1.4.0 was released)
+			action.actionId = ActionId.NextTransitionButtons
+			action.options = {
+				KeyButton: 'KEY',
+				ButtonAction: uskOnPvwMapping[Number(options['USKPvwState'])],
+				BKGDAction: 1,
+			}
+			return true
+		case 'keyOnAir':
+			action.actionId = ActionId.OnAirButtons
+			action.options = { KeyButton: 'KEY', ButtonAction: options['KeyOnAir'] }
+			return true
+		case 'dskOnAir':
+			action.actionId = ActionId.OnAirButtons
+			action.options = { KeyButton: 'DSK', ButtonAction: options['DSKOnAir'] }
+			return true
+		default:
+			return false
+	}
+}
+
+export function tryUpdateNTFeedback(feedback: CompanionMigrationFeedback): boolean {
+	const { feedbackId, options } = feedback
+	switch (feedbackId) {
+		case 'transitionSource':
+			// make sure we're not clobbering a "good" version
+			if (Object.keys(options).includes('KeyTied')) {
+				feedback.feedbackId = FeedbackId.KeysVisibility // this is a no-op
+				feedback.options = { KeyButton: 'KEY', LayerState: options['KeyTied'] }
+				return true
+			} else {
+				// assume object is up-to-date (we could make an explicit test, but it appears to have been consistent)
+				return false
+			}
+		case 'transitionSelection':
+			// doesn't map to new feedback function...
+			//feedback.feedbackId = FeedbackId.KeysVisibility
+			//feedback.options = {KeyButton:  , LayerState: }
+			return false
+		case 'transitionKeySwitch':
+			// note: this works because the option type was incorrectly set to dropdown!
+			feedback.feedbackId = FeedbackId.KeysVisibility
+			feedback.options = { KeyButton: keyswitchMap[String(options['KeySwitch'])], LayerState: 0 }
+			return true
+		case 'keyOnAir':
+			feedback.feedbackId = FeedbackId.KeysVisibility
+			feedback.options = { KeyButton: 'KEY', LayerState: 2 }
+			feedback.isInverted = options['KeyOnAir'] == 0
+			return true
+		case 'dskOnAir':
+			// note: dskOnAir is not in v1.3.1 but we'll do it anyway (it's in 1.4.0)
+			feedback.feedbackId = FeedbackId.KeysVisibility
+			feedback.options = { KeyButton: 'DSK', LayerState: 2 }
+			feedback.isInverted = options['DSKOnAir'] == 0
+			return true
+		case 'keyOnPvw':
+			feedback.feedbackId = FeedbackId.KeysVisibility
+			feedback.options = { KeyButton: 'KEY', LayerState: 3 }
+			feedback.isInverted = options['KeyOnAir'] == 0
+			return true
+		default:
+			return false
+	}
+}

--- a/src/upgrades/upgradeNextTransitiontov1-4.ts
+++ b/src/upgrades/upgradeNextTransitiontov1-4.ts
@@ -76,9 +76,9 @@ export function tryUpdateNTFeedback(feedback: CompanionMigrationFeedback): boole
 				return false
 			}
 		case 'transitionSelection':
-			// doesn't map to new feedback function...
-			//feedback.feedbackId = FeedbackId.KeysVisibility
-			//feedback.options = {KeyButton:  , LayerState: }
+			// doesn't map to new feedback function, but it didn't do anything anyway, so let's just do _something_ ...
+			feedback.feedbackId = FeedbackId.KeysVisibility
+			feedback.options = { KeyButton: 'KEY', LayerState: 0 }
 			return false
 		case 'transitionKeySwitch':
 			// note: this works because the option type was incorrectly set to dropdown!

--- a/src/upgrades/upgradeNextTransitiontov1-4.ts
+++ b/src/upgrades/upgradeNextTransitiontov1-4.ts
@@ -1,12 +1,4 @@
-import {
-	//	CompanionStaticUpgradeResult,
-	//	CompanionUpgradeContext,
-	//	CompanionStaticUpgradeProps,
-	CompanionMigrationAction,
-	CompanionMigrationFeedback,
-	InputValue,
-	//CompanionOptionValues,
-} from '@companion-module/base'
+import { CompanionMigrationAction, CompanionMigrationFeedback, InputValue } from '@companion-module/base'
 
 import { ActionId } from '../functions/mixEffect/actionId'
 import { FeedbackId } from '../functions/mixEffect/feedbackId'
@@ -33,7 +25,7 @@ export function tryUpdateNTAction(action: CompanionMigrationAction): boolean {
 				action.options = { KeyButton: keyName, ButtonAction: 1, BKGDAction: 1 }
 				return true
 			} else {
-				// first optionis now called 'KeyButton', no need to test
+				// first option is now called 'KeyButton', no need to test
 				return false
 			}
 		case 'transitionSourceBG':
@@ -76,12 +68,11 @@ export function tryUpdateNTFeedback(feedback: CompanionMigrationFeedback): boole
 				return false
 			}
 		case 'transitionSelection':
-			// doesn't map to new feedback function, but it didn't do anything anyway, so let's just do _something_ ...
 			feedback.feedbackId = FeedbackId.KeysVisibility
 			feedback.options = { KeyButton: 'KEY', LayerState: 0 }
-			return false
+			return true
 		case 'transitionKeySwitch':
-			// note: this works because the option type was incorrectly set to dropdown!
+			// note: this maintains equivalence because the option type was incorrectly set to dropdown!
 			feedback.feedbackId = FeedbackId.KeysVisibility
 			feedback.options = { KeyButton: keyswitchMap[String(options['KeySwitch'])], LayerState: 0 }
 			return true


### PR DESCRIPTION
Add generic framework for upgrades and add specific
 upgrades to move Next Transition/On Air actions and feedback from v1.3.1 to v1.4.0  NextTransition 

- new file src/upgrades/upgradeNextTransitiontov1-4.ts
- index.ts adds the function `ModuleUpgrader` for the generic upgrading framework. 