### PR TITLE
Add `useVariables` to "Set Record FileName"

### DIFF
--- a/src/functions/record/actions.ts
+++ b/src/functions/record/actions.ts
@@ -41,6 +41,7 @@ export function create(_model: GoStreamModel, state: RecordStateT): CompanionAct
 					id: 'RecordFileName',
 					required: true,
 					default: '',
+					useVariables: true,
 				},
 				{
 					type: 'checkbox',


### PR DESCRIPTION
 Add `useVariables` to "Set Record FileName" so user is given a visual sign that variables are allowed.