### PR TITLE
Fix incorrect "Status Changed" message and other debugging methods

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -69,7 +69,7 @@ export function connect(instance: GoStreamInstance): void {
 	tcp = new TCPHelper(host, PORT_NUMBER)
 	tcp.on('status_change', (state, message) => {
 		instance.updateStatus(state, message)
-		instance.log('debug', 'Socket reconnected')
+		instance.log('debug', 'Status Changed to ' + state + (message != undefined ? ': ' + message : ''))
 	})
 	tcp.on('connect', () => {
 		instance.updateStatus(InstanceStatus.Ok)
@@ -90,9 +90,12 @@ export function connect(instance: GoStreamInstance): void {
 				// Do nothing
 			})
 	})
-	tcp.on('error', () => {
+	tcp.on('error', (err) => {
 		instance.updateStatus(InstanceStatus.ConnectionFailure, 'Connection error')
-		instance.log('debug', 'Socket connect error')
+		instance.log('debug', 'Socket connect error: ' + err)
+	})
+	tcp.on('drain', () => {
+		instance.log('debug', 'Socket drain')
 	})
 	tcp.on('end', () => {
 		instance.updateStatus(InstanceStatus.Disconnected, 'Disconnecting')


### PR DESCRIPTION
- status changed debug message now reports the arguments passed
- also add `on 'drain'` for debugging completeness
- add and use `on 'error'` error-message argument

Fixes issue #131