### PR TITLE
Fix misplaced upgrade script for mask actions

### DIFF
--- a/src/upgrades/index.ts
+++ b/src/upgrades/index.ts
@@ -5,6 +5,7 @@ import {
 	CompanionMigrationAction,
 	CompanionStaticUpgradeScript,
 	CompanionMigrationFeedback,
+	EmptyUpgradeScript,
 } from '@companion-module/base'
 
 import * as UpgradeToConsolidatedSSRCMaskAction from './upgradeToConsolidatedSSRCMaskAction'
@@ -47,7 +48,9 @@ export function ModuleUpgrader(
 // Note: the number of items in this list must grow monotonically, and new items must be added to the end for this to work properly
 // (In some cases very old upgraders can be replaced by EmptyUpgradeScript)
 export const UpgradeScriptList: CompanionStaticUpgradeScript<Config>[] = [
+	EmptyUpgradeScript,
 	UpgradeToV15.getScripts,
 	UpgradeToConsolidatedSSRCMaskAction.getScripts,
 	ModuleUpgrader(tryUpdateNTAction, tryUpdateNTFeedback),
+	UpgradeToV15.getScripts,
 ]


### PR DESCRIPTION
- note: replacing the misplaced script with `EmptyUpgradeScript` allows it to run for the dev group (Ari & Paul). For people starting with a stable version this is still safe because my UpdateNT... scripts will not change upgraded actions.