### PR TITLE
Add sequencing API and use it for PVW & PGM source and Transition Style

### DIFF
--- a/src/functions/mixEffect/actionId.ts
+++ b/src/functions/mixEffect/actionId.ts
@@ -1,6 +1,8 @@
 export enum ActionId {
 	PgmIndex = 'pgmIndex',
+	PgmIndexSequence = 'pgmIndexSequence',
 	PvwIndex = 'pvwIndex',
+	PvwIndexSequence = 'pvwIndexSequence',
 	CutTransition = 'cutTransition',
 	AutoTransition = 'autoTransition',
 	FTB = 'ftb',

--- a/src/functions/mixEffect/actions.ts
+++ b/src/functions/mixEffect/actions.ts
@@ -62,7 +62,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 		[ActionId.PgmIndexSequence]: {
 			name: createActionName('Set a PGM Source Sequence'),
 			description:
-				'Choose a set of input sources to cycle through, either sequentially or randomly. Each button press will advance to the next source. "Random sets" will cycle through the whole set before repeating; "Random selection" allows repeats any time.',
+				'Choose a set of input sources to cycle through, either sequentially or randomly. Each button press will advance to the next source. "Random sets" will cycle through the whole set before repeating; "Fully random" allows repeats any time.',
 			options: setSourceSeqOptions(model),
 			callback: async (action) => {
 				const srcSequence = action.options.Sources as number[]
@@ -74,7 +74,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 		[ActionId.PvwIndexSequence]: {
 			name: createActionName('Set a PVW Source Sequence'),
 			description:
-				'Choose a set of input sources to cycle through, either sequentially or randomly. Each button press will advance to the next source. "Random sets" will cycle through the whole set before repeating; "Random selection" allows repeats any time.',
+				'Choose a set of input sources to cycle through, either sequentially or randomly. Each button press will advance to the next source. "Random sets" will cycle through the whole set before repeating; "Fully random" allows repeats any time.',
 			options: setSourceSeqOptions(model),
 			callback: async (action) => {
 				const srcSequence = action.options.Sources as number[]

--- a/src/functions/mixEffect/actions.ts
+++ b/src/functions/mixEffect/actions.ts
@@ -1,8 +1,8 @@
 import { ActionId } from './actionId'
-import { getOptNumber, getOptString } from '../../util'
+import { getOptNumber, getOptString, nextInSequence, sequenceOrderDropdown } from '../../util'
 import { ReqType, ActionType, TransitionStyle } from '../../enums'
 import { sendCommand, sendCommands } from '../../connection'
-import type { CompanionActionDefinitions } from '@companion-module/base'
+import type { CompanionActionDefinitions, SomeCompanionActionInputField } from '@companion-module/base'
 import { TransitionStyleChoice, WipeDirectionChoices, SwitchChoices } from '../../model'
 import { GoStreamModel } from '../../models/types'
 import { MixEffectStateT } from './state'
@@ -10,6 +10,21 @@ import { MixEffectStateT } from './state'
 function createActionName(name: string): string {
 	return 'MixEffect: ' + name
 }
+
+function setSourceSeqOptions(model: GoStreamModel): SomeCompanionActionInputField[] {
+	return [
+		{
+			id: 'Sources',
+			type: 'multidropdown',
+			label: 'Sources',
+			choices: model.InputSources(),
+			// default sequence is all sources:
+			default: model.InputSources().map((val) => val.id),
+		},
+		sequenceOrderDropdown,
+	]
+}
+
 export function create(model: GoStreamModel, state: MixEffectStateT): CompanionActionDefinitions {
 	return {
 		[ActionId.PgmIndex]: {
@@ -42,6 +57,30 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 			callback: async (action) => {
 				const id = getOptNumber(action, 'Source')
 				await sendCommand(ActionId.PvwIndex, ReqType.Set, [id])
+			},
+		},
+		[ActionId.PgmIndexSequence]: {
+			name: createActionName('Set a PGM Source Sequence'),
+			description:
+				'Choose a set of input sources to cycle through, either sequentially or randomly. Each button press will advance to the next source. "Random sets" will cycle through the whole set before repeating; "Random selection" allows repeats any time.',
+			options: setSourceSeqOptions(model),
+			callback: async (action) => {
+				const srcSequence = action.options.Sources as number[]
+				const newSource = nextInSequence(srcSequence, state.PgmSrc, action)
+
+				await sendCommand(ActionId.PgmIndex, ReqType.Set, [newSource])
+			},
+		},
+		[ActionId.PvwIndexSequence]: {
+			name: createActionName('Set a PVW Source Sequence'),
+			description:
+				'Choose a set of input sources to cycle through, either sequentially or randomly. Each button press will advance to the next source. "Random sets" will cycle through the whole set before repeating; "Random selection" allows repeats any time.',
+			options: setSourceSeqOptions(model),
+			callback: async (action) => {
+				const srcSequence = action.options.Sources as number[]
+				const newSource = nextInSequence(srcSequence, state.PvwSrc, action)
+
+				await sendCommand(ActionId.PvwIndex, ReqType.Set, [newSource])
 			},
 		},
 		[ActionId.CutTransition]: {
@@ -141,12 +180,27 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 					type: 'dropdown',
 					label: 'Transition Style',
 					id: 'TransitionStyle',
+					choices: TransitionStyleChoice.concat([{ id: -1, label: 'Toggle' }]),
 					default: TransitionStyle.MIX,
+				},
+				{
+					type: 'multidropdown',
+					label: 'Sequence',
+					id: 'TransitionStyleSequence',
 					choices: TransitionStyleChoice,
+					default: TransitionStyleChoice.map((item) => item.id),
+					isVisible: (options) => options.TransitionStyle === -1,
 				},
 			],
 			callback: async (action) => {
-				await sendCommand(ActionId.TransitionIndex, ReqType.Set, [getOptNumber(action, 'TransitionStyle')])
+				let choice = getOptNumber(action, 'TransitionStyle')
+				if (choice === -1) {
+					// Toggle: cycle through all available choices sequentially:
+					const sizes = action.options.TransitionStyleSequence as number[]
+					const curStyle = state.selectTransitionStyle.style
+					choice = nextInSequence(sizes, curStyle) // default order is sequential.
+				}
+				await sendCommand(ActionId.TransitionIndex, ReqType.Set, [choice])
 			},
 		},
 		[ActionId.TransitionRate]: {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,10 +1,11 @@
 import type { CompanionActionEvent, CompanionFeedbackInfo } from '@companion-module/base'
-import { DropdownChoice, DropdownChoiceId } from '@companion-module/base'
+import { DropdownChoice, DropdownChoiceId, SomeCompanionActionInputField } from '@companion-module/base'
 
 type DropdownSpec = {
 	choices: DropdownChoice[]
 	default: DropdownChoiceId
 }
+
 export function getOptNumber(
 	action: CompanionActionEvent | CompanionFeedbackInfo,
 	key: string,
@@ -39,11 +40,125 @@ export function Range(end: number): number[] {
 
 /* makeChoices returns {choices: [], default: x} 
   so use ... (spread operator) to include the value in the dropdown description */
-export function makeChoices(values: (number | string)[]): DropdownSpec {
+export function makeChoices(values: (number | string)[], moreOptions: DropdownChoice[] = []): DropdownSpec {
 	return {
-		choices: values.map((size) => {
-			return { id: size, label: String(size) }
-		}),
+		choices: values
+			.map((item) => {
+				return { id: item, label: String(item) }
+			})
+			.concat(moreOptions),
 		default: values[0],
 	}
+}
+
+// return a randomly selected index for the specified array.
+export function getRandomIndex(arr: any[]): number {
+	// random returns [0..1) so the upper bound is exclusive.
+	// Array length is one larger than the highest valid index, so this works perfectly:
+	return Math.floor(Math.random() * arr.length)
+}
+
+export enum sequenceOp {
+	Sequential = 0,
+	RandomWithoutReplacement = 1,
+	RandomWithReplacement = 2,
+}
+
+// generally, use `sequenceOrderDropdown` not this const in action definitions
+export const sequenceOpChoices = [
+	{ id: sequenceOp.Sequential, label: 'sequential' },
+	{ id: sequenceOp.RandomWithoutReplacement, label: 'random sets' },
+	{ id: sequenceOp.RandomWithReplacement, label: 'fully random' },
+]
+
+// "clients" should add this to an action definition for use with `nextInSequence`
+export const sequenceOrderDropdown: SomeCompanionActionInputField = {
+	id: 'Order',
+	type: 'dropdown',
+	label: 'Order',
+	choices: sequenceOpChoices,
+	default: 0,
+}
+
+// a static dict to store remaining selection when drawing randomly without replacement.
+nextInSequence.remaining = new Map<string, number[]>()
+
+// Pick the next item in a set either sequentially or randomly.
+export function nextInSequence(
+	optSequence: number[], // the full ordered set
+	currentOpt: number, // the currently selected item, from state (may not be in srcSequence)
+	action: CompanionActionEvent | sequenceOp = sequenceOp.Sequential, // traversal order
+	uniqueID = '', //  if picking without replacement, but not providing the CompanionActionEvent, then provide a unique ID to associate with the current status
+): number {
+	let currentOptPos = optSequence.indexOf(currentOpt) // the position or -1
+	let newIdx = currentOptPos
+	let newOption: number
+	let order: sequenceOp
+
+	// Parse the third argument
+	if (typeof action === 'number') {
+		order = action
+		if (order === sequenceOp.RandomWithoutReplacement && uniqueID == '') {
+			console.log(
+				'nextInSequence: RandomWithoutReplacement must either be part of an action or uniqueID must be supplied',
+			)
+			throw new Error(
+				'nextInSequence: RandomWithoutReplacement must either be part of an action or uniqueID must be supplied',
+			)
+		}
+	} else if ('Order' in action.options) {
+		order = action.options.Order as number
+		uniqueID = action.id
+	} else {
+		console.log('nextInSequence: Order not specified implicitly or explicitly')
+		throw new Error('nextInSequence: Order not specified implicitly or explicitly')
+	}
+
+	// retrieve or initialize the data store for RandomWithoutReplacement
+	let remaining = nextInSequence.remaining.get(uniqueID)
+	if (remaining === undefined) {
+		remaining = []
+		if (order === sequenceOp.RandomWithoutReplacement) {
+			nextInSequence.remaining.set(uniqueID, remaining)
+		}
+	}
+
+	switch (order) {
+		case sequenceOp.Sequential:
+			newIdx += 1
+			if (newIdx >= optSequence.length) {
+				newIdx = 0
+			}
+			break
+		case sequenceOp.RandomWithReplacement:
+			newIdx = getRandomIndex(optSequence)
+			break
+		case sequenceOp.RandomWithoutReplacement:
+			// When "bucket" is empty, start over:
+			if (remaining.length === 0) {
+				// modify the caller's array.
+				remaining.splice(0, 1, ...optSequence) // makes a shallow copy, which protects srcSequence
+				// currentSrcPos is correct now.
+			}
+			if (remaining.length != optSequence.length || optSequence.length <= 2) {
+				// current bucket was not just refilled, just pick randomly.
+				//  Also handle an edge case: if there are only two items in the full sequence then forcing a change
+				//   when the bucket is refilled will result in sequential (i.e nonrandom) selection.
+				newIdx = -1 // force the while-loop, below, to loop exactly once
+				currentOptPos = -1 // forces a single loop and clears default value
+			}
+			// 'remaining' contains a list of remaing choices to select from, but...
+			// when selecting w/o replacement, it could select the current source at the beginning of a new set.
+			// Make sure that the source always changes (i.e. don't accept current source as the next random value)
+			while (newIdx === currentOptPos) {
+				newIdx = getRandomIndex(remaining)
+			}
+			// remove the selected item from the "bucket" and return it
+			newOption = remaining[newIdx]
+			remaining.splice(newIdx, 1)
+			return newOption
+		default:
+			throw new Error('Function nextInSequence called with illegal value ' + order)
+	}
+	return optSequence[newIdx]
 }


### PR DESCRIPTION
Add sequencing API and use it for PVW & PGM source and Transition Style
- user specifies the set of sources to cycle through
- choose either **sequential** order, **'random sets'** (no repeat until all sources have been selected), **'fully random'** (may repeat any time, aka selection with replacement).
- Transition Style is modified as an example showing a second way to use this API for actions with only 3-4 choices (no random sequences, just add a choice to the dropdown menu).

This addresses issues #21 and #126 (#126 in specific will be addressed in a subsequent PR)

## Some details:
Buttons defined with these actions can use the corresponding variables as their label text, so the button shows the current value.

The "sequencing" API is contained in util.ts.

It consists of a dropdown menu (`sequenceOrderDropdown`) and a function to be embedded in the action's callback (`nextInSequence`)

`nextInSequence` is designed with two modes in mind:

1. Long Sequences with options for random selection: --  Create a new action with a multidropdown contain all of the options. `default:` should be set to all of the options. -- Add `sequenceOrderDropdown`as the next element in the `options:` array -- Define the action callback something like:
~~~
  callback: async (action) => {
        const srcSequence = action.options.Sources as number[]
        const newSource = nextInSequence(srcSequence, state.PgmSrc, action)

        await sendCommand(ActionId.PvwIndex, ReqType.Set, [newSource])
    }
~~~
The first arg is the multidropdown selections, the second arg is the current state of the item.

2. Short (3-4 item) sequences, sequential option only -- Add something like `{ id: -1, label: 'Toggle' }` to the dropdown choices. -- optionally add a multidropdown with all available choices, as above. -- add code similar to:
~~~
  callback: async (action) => {
    	let choice = getOptNumber(action, 'TransitionStyle')
    	if (choice === -1) {
    		// Toggle: cycle through all available choices sequentially:
    		const sizes = action.options.TransitionStyleSequence as number[]
    		const curStyle = state.selectTransitionStyle.style
    		choice = nextInSequence(sizes, curStyle) // default order is sequential.
    	}
    	await sendCommand(ActionId.TransitionIndex, ReqType.Set, [choice])
    },
~~~

# visual examples:
# **_Type 1: (PVW Source)_**
![image](https://github.com/user-attachments/assets/725ecbc8-78ee-48c0-91fd-bda19e547239)


# **_Type 2: (Transition Type_**)
 note that the second pulldown is hidden if toggle isn't selected)
![image](https://github.com/user-attachments/assets/35d77f92-0a75-4f76-934b-4685aae91b38)


