### PR TITLE
Add sequencing options for PIP size and PIP/Pattern/USK fill source

### DIFF
--- a/src/functions/upstreamKeyer/actionId.ts
+++ b/src/functions/upstreamKeyer/actionId.ts
@@ -1,5 +1,6 @@
 export enum ActionId {
 	UpStreamKeyFillKeyType = 'upStreamKeyFillKeyType',
+	UpStreamKeyFillKeySequence = 'upStreamKeyFillKeyTypeSequence',
 	UpStreamKeyType = 'upStreamKeyType',
 	LumaKeySourceFill = 'lumaKeySourceFill',
 	LumaKeySourceKey = 'lumaKeySourceKey',
@@ -36,6 +37,7 @@ export enum ActionId {
 	ChromaKeyControlBackground = 'chromaKeyControlBackground',
 	ChromaKeyControlKeyEdge = 'chromaKeyControlKeyEdge',
 	KeyPatternSourceFill = 'keyPatternSourceFill',
+	PatternSourceFillSequence = 'keyPatternSourceFillSequence',
 	KeyPatternWipePattern = 'keyPatternWipePattern',
 	KeyPatternWipeSize = 'keyPatternWipeSize',
 	KeyPatternWipeXPosition = 'keyPatternWipeXPosition',
@@ -53,6 +55,7 @@ export enum ActionId {
 	KeyPatternResizeXPosition = 'keyPatternResizeXPosition',
 	KeyPatternResizeYPosition = 'keyPatternResizeYPosition',
 	PipSource = 'pipSource',
+	PipSourceSequence = 'pipSourceSequence',
 	PipSize = 'pipSize',
 	PipXPosition = 'pipXPosition',
 	PipYPosition = 'pipYPosition',

--- a/src/functions/upstreamKeyer/keyTypes/keyPattern.ts
+++ b/src/functions/upstreamKeyer/keyTypes/keyPattern.ts
@@ -1,10 +1,11 @@
 import { ActionId } from '../actionId'
-import { getOptNumber, getOptString } from './../../../util'
+import { setUSKSourceSeqOptions } from './../actions'
+import { getOptNumber, getOptString, nextInSequence } from './../../../util'
 import { SwitchChoices, KeyResizeSizeChoices } from './../../../model'
 import { ReqType, ActionType } from './../../../enums'
 import { sendCommand, sendCommands, GoStreamCmd } from './../../../connection'
 import type { CompanionActionDefinitions } from '@companion-module/base'
-import { UpstreamKeyerStateT, USKKeyTypes } from '../state'
+import { UpstreamKeyerStateT, USKKeyTypes, USKKeySourceType } from '../state'
 import { GoStreamModel } from '../../../models/types'
 
 export function createKeyPatternActions(model: GoStreamModel, state: UpstreamKeyerStateT): CompanionActionDefinitions {
@@ -30,6 +31,19 @@ export function createKeyPatternActions(model: GoStreamModel, state: UpstreamKey
 			],
 			callback: async (action) => {
 				await sendCommand(ActionId.KeyPatternSourceFill, ReqType.Set, [getOptNumber(action, 'KeyFill')])
+			},
+		},
+		[ActionId.PatternSourceFillSequence]: {
+			name: 'UpStream Key:Set a Pattern Source Sequence',
+			description:
+				'Choose a set of input sources to cycle through, either sequentially or randomly. Each button press will advance to the next source. "Random sets" will cycle through the whole set before repeating; "Random selection" allows repeats any time.',
+			options: setUSKSourceSeqOptions(model),
+			callback: async (action) => {
+				const srcSequence = action.options.Sources as number[]
+				const curSource = state.keyInfo[USKKeyTypes.KeyPattern].sources[USKKeySourceType.Fill]
+				const newSource = nextInSequence(srcSequence, curSource, action)
+
+				await sendCommand(ActionId.KeyPatternSourceFill, ReqType.Set, [newSource])
 			},
 		},
 		[ActionId.KeyPatternWipePattern]: {

--- a/src/functions/upstreamKeyer/keyTypes/pip.ts
+++ b/src/functions/upstreamKeyer/keyTypes/pip.ts
@@ -1,10 +1,11 @@
 import { ActionId } from './../actionId'
-import { getOptNumber, getOptString, makeChoices } from './../../../util'
-import { SwitchChoices, KeyResizeSizeChoices } from './../../../model'
+import { setUSKSourceSeqOptions } from './../actions'
+import { getOptNumber, getOptString, makeChoices, nextInSequence } from './../../../util'
+import { SwitchChoices } from './../../../model'
 import { ReqType, ActionType } from './../../../enums'
 import { sendCommand, sendCommands, GoStreamCmd } from './../../../connection'
 import type { CompanionActionDefinitions } from '@companion-module/base'
-import { UpstreamKeyerStateT, USKKeyTypes } from '../state'
+import { UpstreamKeyerStateT, USKKeyTypes, USKKeySourceType } from '../state'
 import { GoStreamModel } from '../../../models/types'
 
 // #TODO: these constants should probably be embedded in the model
@@ -33,6 +34,19 @@ export function createPIPActions(model: GoStreamModel, state: UpstreamKeyerState
 				await sendCommand(ActionId.PipSource, ReqType.Set, [getOptNumber(action, 'KeyFill')])
 			},
 		},
+		[ActionId.PipSourceSequence]: {
+			name: 'UpStream Key:Set a Pip Source Sequence',
+			description:
+				'Choose a set of input sources to cycle through, either sequentially or randomly. Each button press will advance to the next source. "Random sets" will cycle through the whole set before repeating; "Random selection" allows repeats any time.',
+			options: setUSKSourceSeqOptions(model),
+			callback: async (action) => {
+				const srcSequence = action.options.Sources as number[]
+				const curSource = state.keyInfo[USKKeyTypes.Pip].sources[USKKeySourceType.Fill]
+				const newSource = nextInSequence(srcSequence, curSource, action)
+
+				await sendCommand(ActionId.PipSource, ReqType.Set, [newSource])
+			},
+		},
 		[ActionId.PipSize]: {
 			name: 'UpStream Key:Set PIP Size',
 			options: [
@@ -40,21 +54,26 @@ export function createPIPActions(model: GoStreamModel, state: UpstreamKeyerState
 					type: 'dropdown',
 					label: 'Size',
 					id: 'PipSize',
+					...makeChoices(state.keyScalingSizes(), [{ id: -1, label: 'Toggle' }]),
+				},
+				{
+					type: 'multidropdown',
+					label: 'Sequence',
+					id: 'PipSizeSet',
 					...makeChoices(state.keyScalingSizes()),
+					default: state.keyScalingSizes(), // replace the non-multidropdown default provided by makeChoices
+					isVisible: (options) => options.PipSize === -1,
 				},
 			],
 			callback: async (action) => {
-				const choice = getOptNumber(action, 'PipSize')
-				if (Number.isInteger(choice)) {
-					// backward compatibility: choice is 0, 1, 2...
-					const info = KeyResizeSizeChoices.find((s) => s.id === action.options.PipSize)
-					if (info !== null && info !== undefined) {
-						const value = Number(info.id)
-						await sendCommand(ActionId.PipSize, ReqType.Set, [value])
-					}
-				} else {
-					await sendCommand(ActionId.PipSize, ReqType.Set, [state.encodeKeyScalingSize(choice)])
+				let choice = getOptNumber(action, 'PipSize')
+				if (choice === -1) {
+					// Toggle: cycle through all available choices sequentially:
+					const sizes = action.options.PipSizeSet as number[]
+					const curSize = state.keyInfo[USKKeyTypes.Pip].size
+					choice = nextInSequence(sizes, curSize)
 				}
+				await sendCommand(ActionId.PipSize, ReqType.Set, [state.encodeKeyScalingSize(choice)])
 			},
 		},
 		[ActionId.PipXPosition]: {


### PR DESCRIPTION
Add sequencing options for PIP size and PIP/Pattern/USK fill source
- PiP and Pattern fill source makes sense to have on sequence, but I'm having trouble justifying the same for Chroma and Luma, in which the fill tends to be specialized and not something you'd "flip channels" through. As a compromise, "current USK source" fill also allows sequencing.
- Putting PiP size in a "toggle" sequence can free up two buttons with almost no downside, especially one would expect the setup to be done in PVW.

note: these all share code, so are put in a single PR.