### PR TITLE
Add Sequencing for USK Key Type, fix types in `nextInSequence`

### DIFF
--- a/src/functions/mixEffect/actions.ts
+++ b/src/functions/mixEffect/actions.ts
@@ -198,7 +198,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 					// Toggle: cycle through all available choices sequentially:
 					const sizes = action.options.TransitionStyleSequence as number[]
 					const curStyle = state.selectTransitionStyle.style
-					choice = nextInSequence(sizes, curStyle) // default order is sequential.
+					choice = nextInSequence(sizes, curStyle) as number // default order is sequential.
 				}
 				await sendCommand(ActionId.TransitionIndex, ReqType.Set, [choice])
 			},

--- a/src/functions/upstreamKeyer/keyTypes/pip.ts
+++ b/src/functions/upstreamKeyer/keyTypes/pip.ts
@@ -71,7 +71,7 @@ export function createPIPActions(model: GoStreamModel, state: UpstreamKeyerState
 					// Toggle: cycle through all available choices sequentially:
 					const sizes = action.options.PipSizeSet as number[]
 					const curSize = state.keyInfo[USKKeyTypes.Pip].size
-					choice = nextInSequence(sizes, curSize)
+					choice = nextInSequence(sizes, curSize) as number
 				}
 				await sendCommand(ActionId.PipSize, ReqType.Set, [state.encodeKeyScalingSize(choice)])
 			},

--- a/src/util.ts
+++ b/src/util.ts
@@ -81,18 +81,18 @@ export const sequenceOrderDropdown: SomeCompanionActionInputField = {
 }
 
 // a static dict to store remaining selection when drawing randomly without replacement.
-nextInSequence.remaining = new Map<string, number[]>()
+nextInSequence.remaining = new Map<string, DropdownChoiceId[]>()
 
 // Pick the next item in a set either sequentially or randomly.
 export function nextInSequence(
-	optSequence: number[], // the full ordered set
-	currentOpt: number, // the currently selected item, from state (may not be in srcSequence)
+	optSequence: DropdownChoiceId[], // the full ordered set
+	currentOpt: DropdownChoiceId, // the currently selected item, from state (may not be in srcSequence)
 	action: CompanionActionEvent | sequenceOp = sequenceOp.Sequential, // traversal order
 	uniqueID = '', //  if picking without replacement, but not providing the CompanionActionEvent, then provide a unique ID to associate with the current status
-): number {
+): DropdownChoiceId {
 	let currentOptPos = optSequence.indexOf(currentOpt) // the position or -1
 	let newIdx = currentOptPos
-	let newOption: number
+	let newOption: DropdownChoiceId
 	let order: sequenceOp
 
 	// Parse the third argument


### PR DESCRIPTION
Add Sequencing for USK Key Type, fix types in `nextInSequence`
- USK Key type is a string rather than number (new internal format) so "broke" `nextInSequence`
- Change input and return types in `nextInSequence`to `DropdownChoiceId`
- need to do some typecasting in the previous functions to make it all work.