### PR TITLE
Run `yarn format` on v1.6 -- reformats the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ struct GoStreamCommand:
   type: CommandType
   value?: (number|string)[]
 ```
+
 each command is embedded in a packet with a header and a CRC 16 modbus sum
 
 ```
@@ -73,22 +74,24 @@ The GoStream device might send several GoStreamPackets in the same Ethernet fram
 
 ## Notes on module development
 
-The Osee GoStream module follows as long as possible the [semver major.minor.patch format](https://semver.org/) . 
-* MAJOR version increases with incompatible API changes or big refactoring works 
-* MINOR version increases with added functionality in a backward compatible manner
-* PATCH version increases when a release has regressed from the prior release. 
-  
-As Companion supports upgrade scripts not all non backwards compatible changes will require a major number increase. If upgrade is possible then 
-just a minor number increase is needed. 
+The Osee GoStream module follows as long as possible the [semver major.minor.patch format](https://semver.org/) .
+
+- MAJOR version increases with incompatible API changes or big refactoring works
+- MINOR version increases with added functionality in a backward compatible manner
+- PATCH version increases when a release has regressed from the prior release.
+
+As Companion supports upgrade scripts not all non backwards compatible changes will require a major number increase. If upgrade is possible then
+just a minor number increase is needed.
 A PATCH release should be made only on regression of the sw, i.e. when something that previously worked stopped working. There are probably several unknown
 bugs in the current sw, as these are discovered they do not warrant a patch release but should be planned in a future minor release.
 
-Three "active" branches exists at any given time; stable, current , a future branch . 
-* FUTURE branch is for developing the major releases.
-* CURRENT branch is where normal developing goes.
-* STABLE branch is only open for fixes.
+Three "active" branches exists at any given time; stable, current , a future branch .
 
-Branches are named v{major}.{minor} and are based from main . Labeling for companion releases occurs on each branch not on main . 
+- FUTURE branch is for developing the major releases.
+- CURRENT branch is where normal developing goes.
+- STABLE branch is only open for fixes.
+
+Branches are named v{major}.{minor} and are based from main . Labeling for companion releases occurs on each branch not on main .
 There is no need to branch out from a release branch for patches , these can just continue the normal commit flow .
 
 When a release is made an uplift to main occurs, then uplift to all other branches (if needed) takes place from main


### PR DESCRIPTION
(otherwise it puts README.md in my commit every time I run yarn format!)
