### PR TITLE
Add sequences for Aux and Output Sources

### DIFF
--- a/src/functions/settings/actionId.ts
+++ b/src/functions/settings/actionId.ts
@@ -7,6 +7,7 @@ export enum ActionId {
 	MicInput = 'micInput',
 	SrcSelection = 'srcSelection',
 	AuxSource = 'auxSource',
+	StorageDevice = 'storageDevice',
 	OutFormat = 'outFormat',
 	OutputColorSpace = 'outputColorSpace',
 	OutSource = 'outSource',

--- a/src/functions/settings/state.ts
+++ b/src/functions/settings/state.ts
@@ -10,7 +10,9 @@ export type NDISource = {
 }
 
 export type SettingsStateT = {
+	model: GoStreamModel
 	auxSource: number
+	storageDevice: string
 	inputWindowLayout: number
 	mvMeter: number[]
 	outSource: number[] // hdmi1, hdmi2, uvc
@@ -36,7 +38,9 @@ export function create(model: GoStreamModel): SettingsStateT {
 	const colorSpaceCapableOutputs = model.outputs.filter((out) => out.caps & PortCaps.Colorspace).length
 	const srcSelectable = model.inputs.filter((inp) => inp.type & (PortType.HDMI | PortType.SDI)).length
 	return {
+		model: model,
 		auxSource: 0,
+		storageDevice: '',
 		inputWindowLayout: 0,
 		mvMeter: Array(audioCapableInputs),
 		outSource: Array(model.outputs.length),
@@ -65,6 +69,7 @@ export async function sync(model: GoStreamModel): Promise<boolean> {
 	const srcSelectable = model.inputs.filter((inp) => inp.type & (PortType.HDMI | PortType.SDI)).length
 	const cmds: GoStreamCmd[] = [
 		{ id: ActionId.AuxSource, type: ReqType.Get },
+		{ id: ActionId.StorageDevice, type: ReqType.Get },
 		...Range(model.outputs.length).map((id) => ({ id: ActionId.OutSource, type: ReqType.Get, value: [id] })),
 		{ id: ActionId.InputWindowLayout, type: ReqType.Get },
 		...Range(audioCapableInputs).map((id) => ({ id: ActionId.MvMeter, type: ReqType.Get, value: [id] })),
@@ -104,6 +109,9 @@ export function update(state: SettingsStateT, data: GoStreamCmd): boolean {
 			}
 			break
 		}
+		case ActionId.StorageDevice:
+			state.storageDevice = String(data.value![0])
+			break
 		case ActionId.InputWindowLayout:
 			state.inputWindowLayout = Number(data.value![0])
 			break

--- a/src/functions/settings/variables.ts
+++ b/src/functions/settings/variables.ts
@@ -1,7 +1,9 @@
 import { CompanionVariableDefinition, CompanionVariableValues } from '@companion-module/base'
 import { GoStreamModel } from '../../models/types'
 import { SettingsStateT } from './state'
-export function create(_model: GoStreamModel): CompanionVariableDefinition[] {
+import { SettingsAuxSourceChoices } from './../../model'
+
+export function create(model: GoStreamModel): CompanionVariableDefinition[] {
 	const vars: CompanionVariableDefinition[] = []
 	for (let i = 0; i < 9; i++) {
 		vars.push({
@@ -34,6 +36,23 @@ export function create(_model: GoStreamModel): CompanionVariableDefinition[] {
 		name: 'connected NDI source address',
 		variableId: 'connectedNDISource_address',
 	})
+	vars.push({
+		name: 'Aux Source',
+		variableId: 'auxSource',
+	})
+	vars.push({
+		name: 'Aux Storage Device',
+		variableId: 'auxStorageDevice',
+	})
+
+	for (const dditem of model.outputPorts) {
+		const outport = dditem.label
+		const output_sym = outport.replaceAll(' ', '_')
+		vars.push({
+			name: `${outport} Output Source`,
+			variableId: `OutputSource_${output_sym}`,
+		})
+	}
 
 	return vars
 }
@@ -50,5 +69,19 @@ export function getValues(state: SettingsStateT): CompanionVariableValues {
 
 	newValues['connectedNDISource_name'] = state.connectedNdiSource.name
 	newValues['connectedNDISource_address'] = state.connectedNdiSource.address
+
+	newValues['auxSource'] = SettingsAuxSourceChoices.find((item) => item.id === state.auxSource)?.label
+	newValues['auxStorageDevice'] = state.storageDevice
+
+	// Output Sources
+	for (const dditem of state.model.outputPorts) {
+		const outport = dditem.label
+		const output_sym = outport.replaceAll(' ', '_')
+		const idx = dditem.id
+		newValues[`OutputSource_${output_sym}`] = state.model
+			.OutputSources()
+			.find((item) => item.id === state.outSource[idx])?.label
+	}
+
 	return newValues
 }


### PR DESCRIPTION
Add sequences for Aux and Output Sources
- Aux Source
- HDMI 1/ HDMI 2/ UVC Output
- Add descriptions to most settings actions (unrelated to the sequences)

Note: these are primarily intended to be used a "simple" toggles in which the user selects a subset of the options only. For example, toggle Aux Source between UVC In and Player (skipping NDI), or toggle HDMI 1 between In 4 and PGM (something I actually do). While I can imagine a use-case for random cycling to HDMI out, such functionality is not currently implemented.