### PR TITLE
Add tracking and variables for playback

### DIFF
--- a/src/functions/playback/actionId.ts
+++ b/src/functions/playback/actionId.ts
@@ -6,4 +6,5 @@ export enum ActionId {
 	PlaybackBar = 'playbackBar',
 	PlayFile = 'playFile',
 	PlaybackList = 'playbackList',
+	PlaybackPlayhead = 'playbackSkip',
 }

--- a/src/functions/playback/state.ts
+++ b/src/functions/playback/state.ts
@@ -9,6 +9,8 @@ export type PlaybackStateT = {
 	Pause: boolean
 	Bar: boolean
 	File: number
+	Playhead: number
+	Playlength: number
 	// Not really state variable, hold videofile list
 	// TODO: place somewhere more logical
 	FileList: string[]
@@ -20,6 +22,8 @@ export function create(_model: GoStreamModel): PlaybackStateT {
 		Repeat: false,
 		Pause: false,
 		Bar: false,
+		Playhead: 0,
+		Playlength: 0,
 		File: 0,
 		FileList: [],
 	}
@@ -32,6 +36,7 @@ export async function sync(_model: GoStreamModel): Promise<boolean> {
 		{ id: ActionId.PlaybackPause, type: ReqType.Get },
 		{ id: ActionId.PlaybackBar, type: ReqType.Get },
 		{ id: ActionId.PlaybackList, type: ReqType.Get },
+		{ id: ActionId.PlaybackPlayhead, type: ReqType.Get },
 	]
 	return await sendCommands(cmds)
 }
@@ -51,6 +56,10 @@ export function update(state: PlaybackStateT, data: GoStreamCmd): boolean {
 			break
 		case ActionId.PlayFile:
 			state.File = state.FileList.indexOf(String(data.value![0]))
+			break
+		case ActionId.PlaybackPlayhead:
+			state.Playhead = Number(data.value![0])
+			state.Playlength = Number(data.value![1])
 			break
 		case ActionId.PlaybackList:
 			if (!('value' in data)) {

--- a/src/functions/playback/variableId.ts
+++ b/src/functions/playback/variableId.ts
@@ -1,4 +1,9 @@
 export enum VariableId {
 	PlayState = 'PlayState',
 	PlayFile = 'PlayFile',
+	PlaybackPlayhead = 'Playhead', // this is not a communication ID. It is part of playbackSkip
+	PlaybackPlaylength = 'PlaybackLength', // this is not a communication ID. It is part of playbackSkip
+	PlaybackPlayheadMMSS = 'PlayheadMMSS',
+	PlaybackRemainingMMSS = 'PlaybackRemainingMMSS',
+	PlaybackPlaylengthMMSS = 'PlaybackLengthMMSS',
 }

--- a/src/functions/playback/variables.ts
+++ b/src/functions/playback/variables.ts
@@ -5,19 +5,62 @@ import { PlaybackStateT } from './state'
 export function create(_model: GoStreamModel): CompanionVariableDefinition[] {
 	return [
 		{
-			name: 'Play State of PlayBack',
+			name: 'Playback state (play/pause)',
 			variableId: VariableId.PlayState,
 		},
 		{
 			name: 'Loaded video file',
 			variableId: VariableId.PlayFile,
 		},
+		{
+			name: 'Playhead (s)',
+			variableId: VariableId.PlaybackPlayhead,
+		},
+		{
+			name: 'Video length (s)',
+			variableId: VariableId.PlaybackPlaylength,
+		},
+		{
+			name: 'Playhead (MM:SS)',
+			variableId: VariableId.PlaybackPlayheadMMSS,
+		},
+		{
+			name: 'Time remaining (MM:SS)',
+			variableId: VariableId.PlaybackRemainingMMSS,
+		},
+		{
+			name: 'Video length (MM:SS)',
+			variableId: VariableId.PlaybackPlaylengthMMSS,
+		},
 	]
+}
+
+function asMMSS(seconds: number, maxval: number = seconds): string {
+	// return "MM:SS" if interval is less than an hour; otherwise "HH:MM:SS"
+	//  if maxval is specified, it is used for deciding whether to add "HH:"
+	//  (so if cliplength is 1:00:00 but time remaining is 40s, it will still format it to match cliplength)
+	let minutes = Math.floor(seconds / 60)
+	seconds -= minutes * 60
+	const hours = Math.floor(minutes / 60)
+	if (hours > 0) {
+		minutes -= hours * 60
+	}
+
+	const hourStr = (hours < 10 ? '0' : '') + hours + ':'
+	const minutesStr = (minutes < 10 ? '0' : '') + minutes + ':'
+	const secStr = (seconds < 10 ? '0' : '') + seconds
+
+	return (maxval >= 3600 ? hourStr : '') + minutesStr + secStr
 }
 
 export function getValues(state: PlaybackStateT): CompanionVariableValues {
 	const newValues = {}
 	newValues[VariableId.PlayState] = state.Pause ? 'Play' : 'Pause'
 	newValues[VariableId.PlayFile] = state.FileList[state.File]
+	newValues[VariableId.PlaybackPlayhead] = state.Playhead
+	newValues[VariableId.PlaybackPlaylength] = state.Playlength
+	newValues[VariableId.PlaybackPlayheadMMSS] = asMMSS(state.Playhead, state.Playlength)
+	newValues[VariableId.PlaybackRemainingMMSS] = asMMSS(state.Playlength - state.Playhead)
+	newValues[VariableId.PlaybackPlaylengthMMSS] = asMMSS(state.Playlength)
 	return newValues
 }


### PR DESCRIPTION
Add tracking and variables for playhead
- Osee protocol: playbackSkip provides [playhead, playlength]
- Add variables to state
- Create Companion variables for raw and formatted output: playhead, playlength, playhead/length/remaining in HH:MM:SS (defaults to MM:SS).

resolves issue #173 