### PR TITLE
Create a "unified" transition style set that includes CUT and FTB

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -57,4 +57,6 @@ export const TransitionStyle = {
 	MIX: 0,
 	DIP: 1,
 	WIPE: 2,
+	CUT: 3,
+	FTB: 4,
 }

--- a/src/functions/mixEffect/actions.ts
+++ b/src/functions/mixEffect/actions.ts
@@ -92,9 +92,18 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 		},
 		[ActionId.AutoTransition]: {
 			name: createActionName('Perform AUTO transition'),
+			description:
+				'Auto transition is set by "Set Transition Style" and can be CUT or FTB in addition to the standard MIX, DIP, WIPE.',
 			options: [],
 			callback: async () => {
-				await sendCommand(ActionId.AutoTransition, ReqType.Set)
+				const style = state.autoTransition.style
+				if (style == TransitionStyle.CUT) {
+					await sendCommand(ActionId.CutTransition, ReqType.Set)
+				} else if (style == TransitionStyle.FTB) {
+					await sendCommand(ActionId.FTB, ReqType.Set)
+				} else {
+					await sendCommand(ActionId.AutoTransition, ReqType.Set)
+				}
 			},
 		},
 		[ActionId.FTB]: {
@@ -162,7 +171,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 				const opt = getOptNumber(action, 'prevEnable')
 				let paramOpt = 0
 				if (opt === 2) {
-					if (state.selectTransitionStyle.PrevState === true) {
+					if (state.autoTransition.PrevState === true) {
 						paramOpt = 0
 					} else {
 						paramOpt = 1
@@ -174,7 +183,9 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 			},
 		},
 		[ActionId.TransitionIndex]: {
-			name: createActionName('Set transition style/pattern'),
+			name: createActionName('Set transition style'),
+			description:
+				'Set to one of: MIX, DIP, WIPE, CUT, or FTB. Note that the last two are Companion-only styles: they do not affect the AUTO button on the GoStream panel.',
 			options: [
 				{
 					type: 'dropdown',
@@ -197,10 +208,18 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionA
 				if (choice === -1) {
 					// Toggle: cycle through all selected choices sequentially:
 					const sizes = action.options.TransitionStyleSequence as number[]
-					const curStyle = state.selectTransitionStyle.style
+					const curStyle = state.autoTransition.style
 					choice = nextInSequence(sizes, curStyle) as number // default order is sequential.
 				}
-				await sendCommand(ActionId.TransitionIndex, ReqType.Set, [choice])
+				if (choice === TransitionStyle.CUT || choice === TransitionStyle.FTB) {
+					// note, for "psuedostyles we must set state directly here
+					state.autoTransition.style = choice
+					// then request info, which will trigger updating the variable.
+					await sendCommand(ActionId.TransitionIndex, ReqType.Get)
+				} else {
+					state.autoTransition.style = -1 // reset any current state (otherwise if style was CUT or FTB it won't update)
+					await sendCommand(ActionId.TransitionIndex, ReqType.Set, [choice])
+				}
 			},
 		},
 		[ActionId.TransitionRate]: {

--- a/src/functions/mixEffect/feedbacks.ts
+++ b/src/functions/mixEffect/feedbacks.ts
@@ -133,7 +133,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 				bgcolor: combineRgb(255, 255, 0),
 			},
 			callback: () => {
-				return state.selectTransitionStyle.PrevState
+				return state.autoTransition.PrevState
 			},
 		},
 		[FeedbackId.TransitionStyle]: {
@@ -154,7 +154,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 				bgcolor: combineRgb(255, 255, 0),
 			},
 			callback: (feedback) => {
-				if (state.selectTransitionStyle?.style === feedback.options.TransitionStyle) {
+				if (state.autoTransition.style === feedback.options.TransitionStyle) {
 					return true
 				} else {
 					return false
@@ -171,7 +171,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 					label: 'Transition Style',
 					id: 'TransitionStyle',
 					default: TransitionStyle.MIX,
-					choices: TransitionStyleChoice,
+					choices: TransitionStyleChoice.slice(0, 3), // (exclude CUT and FTB)
 				},
 				{
 					type: 'number',
@@ -189,7 +189,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 				bgcolor: combineRgb(255, 255, 0),
 			},
 			callback: (feedback) => {
-				const me = state.selectTransitionStyle
+				const me = state.autoTransition
 				if (me?.style === feedback.options.TransitionStyle) {
 					const style = Number(feedback.options.TransitionStyle)
 					const rate = Number(feedback.options.TransitionRate)
@@ -208,7 +208,7 @@ export function create(model: GoStreamModel, state: MixEffectStateT): CompanionF
 				return false
 			},
 			learn: (feedback) => {
-				const me = state.selectTransitionStyle
+				const me = state.autoTransition
 				if (me?.style === feedback.options.TransitionStyle) {
 					const style = Number(feedback.options.TransitionStyle)
 					switch (style) {

--- a/src/functions/mixEffect/state.ts
+++ b/src/functions/mixEffect/state.ts
@@ -1,6 +1,6 @@
 import { ActionId } from './actionId'
 import { sendCommands, GoStreamCmd } from '../../connection'
-import { ReqType } from '../../enums'
+import { ReqType, TransitionStyle } from '../../enums'
 import type { GoStreamModel } from '../../models/types'
 
 // Class for next transition group: KEY, DSK, BKGD, OnAir (KEY), OnAir (DSK)
@@ -95,15 +95,13 @@ export type MixEffectStateT = {
 		AFV: boolean
 		rate: number
 	}
-	selectTransitionStyle: {
+	autoTransition: {
 		PrevState: boolean
 		style: number
 		mixrate: number
 		diprate: number
 		wiperate: number
 	}
-	pvwOnAir: boolean
-	tied: boolean
 	nextTState: nextTransitionState
 }
 
@@ -122,15 +120,13 @@ export function create(model: GoStreamModel): MixEffectStateT {
 			AFV: false,
 			rate: 0,
 		},
-		selectTransitionStyle: {
+		autoTransition: {
 			PrevState: false,
 			style: 0,
 			mixrate: 0,
 			diprate: 0,
 			wiperate: 0,
 		},
-		pvwOnAir: false,
-		tied: false,
 		nextTState: new nextTransitionState(),
 	}
 }
@@ -196,22 +192,25 @@ export function update(state: MixEffectStateT, data: GoStreamCmd): boolean {
 			state.fadeToBlack.rate = Number(data.value![0])
 			break
 		case ActionId.Prev:
-			state.selectTransitionStyle.PrevState = Boolean(data.value![0])
+			state.autoTransition.PrevState = Boolean(data.value![0])
 			break
 		case ActionId.TransitionIndex: {
-			const selectValue = Number(data.value![0])
-			state.selectTransitionStyle.style = selectValue
+			// only change the internal state if we're not currently set to one of the pseudovalues.
+			const curStyle = state.autoTransition.style // current style
+			if (curStyle !== TransitionStyle.CUT && curStyle !== TransitionStyle.FTB) {
+				state.autoTransition.style = Number(data.value![0])
+			}
 			break
 		}
 		case ActionId.TransitionRate: {
 			const type = Number(data.value![0])
 			const typeValue = Number(data.value![1])
 			if (type === 0) {
-				state.selectTransitionStyle.mixrate = typeValue
+				state.autoTransition.mixrate = typeValue
 			} else if (type === 1) {
-				state.selectTransitionStyle.diprate = typeValue
+				state.autoTransition.diprate = typeValue
 			} else if (type === 2) {
-				state.selectTransitionStyle.wiperate = typeValue
+				state.autoTransition.wiperate = typeValue
 			}
 			break
 		}

--- a/src/functions/mixEffect/variables.ts
+++ b/src/functions/mixEffect/variables.ts
@@ -29,7 +29,7 @@ export function getValues(state: MixEffectStateT): CompanionVariableValues {
 	const transitionStyle = TransitionStyleChoice.map((item) => item.label)
 	newValues[VariableId.PVW_Source] = inputSources[state.PvwSrc]
 	newValues[VariableId.PGM_Source] = inputSources[state.PgmSrc]
-	newValues[VariableId.TransitionStyle] = transitionStyle[state.selectTransitionStyle.style]
+	newValues[VariableId.TransitionStyle] = transitionStyle[state.autoTransition.style] // note we're assuming that TransitionStyleChoice is numbered consecutively from 0
 
 	return newValues
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -36,6 +36,8 @@ export const TransitionStyleChoice = [
 	{ id: TransitionStyle.MIX, label: 'MIX' },
 	{ id: TransitionStyle.DIP, label: 'DIP' },
 	{ id: TransitionStyle.WIPE, label: 'WIPE' },
+	{ id: TransitionStyle.CUT, label: 'CUT' },
+	{ id: TransitionStyle.FTB, label: 'FTB' },
 ]
 export const SwitchChoices = [
 	{ id: 0, label: 'Off' },


### PR DESCRIPTION
 - modify enum/model definitions to include CUT and FTB
 - modify actions for AUTO transition and Set Transition Style appropriately.
 - completes issue #183
 - "bonus": rename state variable "selectTransitionStyle" to "autoTransition", which is a bit clearer.
 - also remove unused state variables "pvwOnAir" and "tied" (these were replaced by the class nextTransitionState in v1.4, or were never used.)