### PR TITLE
Play first/last in group

### DIFF
--- a/src/functions/playback/actionId.ts
+++ b/src/functions/playback/actionId.ts
@@ -9,4 +9,6 @@ export enum ActionId {
 	PlaybackPlayhead = 'playbackSkip',
 	PlaybackNext = 'playbackNext',
 	PlaybackPrev = 'playbackLast',
+	PlaybackGetAllGroups = 'getPlaybackGroupAll',
+	PlaybackGroup = 'playbackGroup',
 }

--- a/src/functions/playback/feedbackId.ts
+++ b/src/functions/playback/feedbackId.ts
@@ -5,4 +5,5 @@ export enum FeedbackId {
 	PlaybackBar = 'playbackBar',
 	PlayFile = 'playFile',
 	PlaybackNoFiles = 'playbackNoFiles',
+	PlaybackNoGroup = 'playbackNoGroup',
 }

--- a/src/functions/playback/feedbacks.ts
+++ b/src/functions/playback/feedbacks.ts
@@ -1,7 +1,10 @@
 import { FeedbackId } from './feedbackId'
 import { combineRgb, CompanionFeedbackDefinitions } from '@companion-module/base'
 import { PlaybackStateT } from './state'
+import { pbGroupButtons } from './actions'
+import { getOptString } from '../../util'
 import type { GoStreamModel } from '../../models/types'
+
 export function create(_model: GoStreamModel, state: PlaybackStateT): CompanionFeedbackDefinitions {
 	return {
 		[FeedbackId.PlaybackMode]: {
@@ -104,6 +107,47 @@ export function create(_model: GoStreamModel, state: PlaybackStateT): CompanionF
 			},
 			callback: (_feedback) => {
 				return state.FileList.length === 0
+			},
+		},
+		[FeedbackId.PlaybackNoGroup]: {
+			type: 'advanced',
+			name: 'PlayFile:Group is not in groups.ini, or group is empty',
+			description: 'Change button text if group is not specified in the groups.ini file.',
+			options: [
+				{
+					id: 'GroupNameID',
+					type: 'dropdown',
+					label: 'GroupName',
+					choices: [{ id: '*AUTODETECT*', label: "SAME AS BUTTON'S ACTION" }].concat(
+						Array.from(state.Groups.keys()).map((s, _index) => ({
+							id: s,
+							label: s,
+						})),
+					),
+					allowCustom: true,
+					default: '*AUTODETECT*',
+				},
+			],
+			callback: (feedback) => {
+				let groupName = getOptString(feedback, 'GroupNameID')
+				//const opt = getOptNumber(feedback, 'positionID')
+				if (groupName === '*AUTODETECT*') {
+					const action_groupName = pbGroupButtons.get(feedback.controlId)
+					if (action_groupName === undefined) {
+						return {}
+					}
+					groupName = action_groupName
+				}
+				const group = state.Groups.get(groupName)
+				if (group === undefined) {
+					return {
+						color: combineRgb(0, 0, 0),
+						bgcolor: combineRgb(72, 72, 72),
+						text: `Group ${groupName} not found`,
+					}
+				} else {
+					return {}
+				}
 			},
 		},
 	}


### PR DESCRIPTION
Play first/last in group
- add logic to request and process video-file groups
- The action pulldown uses the current group list but also allows user to type in a group that is not on the current storage medium.
- Also included is "demonstration" feedback that reports when the named group is missing. It allows the user to link to the button's action instead of explicitly selecting the groupname again.
- (note feedback is currently implemented as "advanced" in order to give an informative error message -- i.e. have the button text mention the group name. If more control is desired, a second, boolean, feedback could be defined to allow user customization or only a boolean feedback, but at the expense of losing the error message.)
- completes issue #184 